### PR TITLE
Decouple specific coords in farming commands

### DIFF
--- a/bot/cogs/farming.py
+++ b/bot/cogs/farming.py
@@ -15,54 +15,15 @@ CROP_NOT_FOUND = discord.Embed(
     description="The crop specified was not recognized. Please try again."
 )
 
+NO_AVAILABLE_PLOTS = discord.Emned(
+    description="There are no available plots at this time."
+)
+
 INSTRUCTIONS = """
         Usage:
             {prefix}[action] <plots>
         <plots> is optional, and can also be multiple arguments.
-        Rows are enumerated starting at '1'.
-        Columns are labeled starting at 'a'.
-        Example with 0's instead of plots:
-           a   b   c
-        1  0   0   0
-        2  0   0   0
-        3  0   0   0
-        <plots> can be a row, column or a specific plot.
-        Specific plot is specified by row number followed by column label.
-        (for example a1 for the top left plot.)
-        If <plots> is not specified, all plots will be [action]ed.
         """
-
-
-class PlotCoordinateConverter(commands.Converter):
-    async def convert(self, ctx, in_coordinate: str):
-        match_1a = re.match(r"([0-9]+)([A-Za-z]+)", in_coordinate, re.I)
-        match_a1 = re.match(r"([A-Za-z]+)([0-9]+)", in_coordinate, re.I)
-        if match_1a:
-            out_coordinate = match_1a.groups()
-            row = int(out_coordinate[0])
-            column = out_coordinate[1]
-        elif match_a1:
-            out_coordinate = match_a1.groups()
-            column = out_coordinate[0]
-            row = int(out_coordinate[1])
-        else:
-            match_a = re.match(r"[A-Za-z]+", in_coordinate, re.I)
-            match_1 = re.match(r"[0-9]+", in_coordinate, re.I)
-            if match_a:
-                out_coordinate = match_a.group()
-                column = out_coordinate[0]
-                row = None
-            elif match_1:
-                out_coordinate = match_1.group()
-                row = int(out_coordinate)
-                column = None
-            else:
-                raise ValueError
-        column = ord(column.lower()) - ord("a") if column else None
-        row = row - 1 if row else None
-        if (row and row < 0) or (column and column < 0):
-            raise ValueError
-        return PlotCoordinate(row, column)
 
 
 class Farming(commands.Cog):
@@ -84,17 +45,11 @@ class Farming(commands.Cog):
     )
     async def harvest(
         self,
-        ctx,
-        input_coordinates: commands.Greedy[PlotCoordinateConverter],
-        *,
-        catcher: str = None,
+        ctx
     ):
-        valid = True if catcher is None else False
         await self.action(
             ctx,
-            input_coordinates,
             action=PlotActions.HARVEST,
-            valid=valid,
         )
 
     @commands.command(
@@ -102,17 +57,12 @@ class Farming(commands.Cog):
     )
     async def water(
         self,
-        ctx,
-        input_coordinates: commands.Greedy[PlotCoordinateConverter],
-        *,
-        catcher: str = None,
+        ctx
     ):
         valid = True if catcher is None else False
         await self.action(
             ctx,
-            input_coordinates,
             action=PlotActions.WATER,
-            valid=valid,
         )
 
     @commands.command(
@@ -122,40 +72,27 @@ class Farming(commands.Cog):
         self,
         ctx,
         crop_name: str,
-        input_coordinates: commands.Greedy[PlotCoordinateConverter],
-        *,
-        catcher: str = None,
+        amount: int
     ):
         valid = True if catcher is None else False
         await self.action(
             ctx,
-            input_coordinates,
             action=PlotActions.PLANT,
-            valid=valid,
             crop_name=crop_name,
+            amount=amount,
         )
 
     @staticmethod
     async def action(
         ctx,
-        input_coordinates: List[PlotCoordinate],
         action: PlotActions,
         crop_name: str = None,
-        valid: bool = True,
+        amount: int = None
     ):
-        if not valid:
-            return await ctx.send(embed=PLOT_NOT_FOUND)
-
         player = await Player.load(user_id=ctx.author.id, guild_id=ctx.guild.id)
         farm = await Farm.load(player_id=player.id)
-
-        if input_coordinates:
-            for coordinate in input_coordinates:
-                if not farm.validate_coordinate(
-                    row=coordinate.row, column=coordinate.column
-                ):
-                    return await ctx.send(embed=PLOT_NOT_FOUND)
-
+        coordinates = []
+        
         crop_id = None
         if action == PlotActions.PLANT:
             for key, value in CROP_DATA.items():
@@ -164,9 +101,15 @@ class Farming(commands.Cog):
                     break
             if crop_id is None:
                 return await ctx.send(embed=CROP_NOT_FOUND)
+            coordinates = farm.get_plots(planted=False)
+            if amount < len(coordinates):
+                coordinates = coordinates[:amount]
+        else:
+            if action == PlotActions.HARVEST or action == PlotActions.WATER:
+                coordinates = farm.get_plots(planted=True)
 
         await farm.work_plots(
-            action=action, coordinates=input_coordinates, crop_id=crop_id
+            action=action, coordinates=coordinates, crop_id=crop_id
         )
 
         await ctx.send(embed=farm.display())

--- a/bot/cogs/farming.py
+++ b/bot/cogs/farming.py
@@ -1,10 +1,8 @@
 import discord
 from discord.ext import commands
-import re
-from typing import List
 
 from bot.game import Farm, Player
-from bot.utils.constants import PlotCoordinate, PlotActions, CROP_DATA
+from bot.utils.constants import PlotActions, CROP_DATA
 
 
 PLOT_NOT_FOUND = discord.Embed(
@@ -43,10 +41,7 @@ class Farming(commands.Cog):
     @commands.command(
         brief="*Harvest your crops*", help=INSTRUCTIONS.replace("[action]", "harvest")
     )
-    async def harvest(
-        self,
-        ctx
-    ):
+    async def harvest(self, ctx):
         await self.action(
             ctx,
             action=PlotActions.HARVEST,
@@ -55,11 +50,7 @@ class Farming(commands.Cog):
     @commands.command(
         brief="*Water your crops*", help=INSTRUCTIONS.replace("[action]", "water")
     )
-    async def water(
-        self,
-        ctx
-    ):
-        valid = True if catcher is None else False
+    async def water(self, ctx):
         await self.action(
             ctx,
             action=PlotActions.WATER,
@@ -68,13 +59,7 @@ class Farming(commands.Cog):
     @commands.command(
         brief="*Plant your crops*", help=INSTRUCTIONS.replace("[action]", "plant")
     )
-    async def plant(
-        self,
-        ctx,
-        crop_name: str,
-        amount: int
-    ):
-        valid = True if catcher is None else False
+    async def plant(self, ctx, crop_name: str, amount: int):
         await self.action(
             ctx,
             action=PlotActions.PLANT,
@@ -84,15 +69,12 @@ class Farming(commands.Cog):
 
     @staticmethod
     async def action(
-        ctx,
-        action: PlotActions,
-        crop_name: str = None,
-        amount: int = None
+        ctx, action: PlotActions, crop_name: str = None, amount: int = None
     ):
         player = await Player.load(user_id=ctx.author.id, guild_id=ctx.guild.id)
         farm = await Farm.load(player_id=player.id)
         coordinates = []
-        
+
         crop_id = None
         if action == PlotActions.PLANT:
             for key, value in CROP_DATA.items():
@@ -108,9 +90,7 @@ class Farming(commands.Cog):
             if action == PlotActions.HARVEST or action == PlotActions.WATER:
                 coordinates = farm.get_plots(planted=True)
 
-        await farm.work_plots(
-            action=action, coordinates=coordinates, crop_id=crop_id
-        )
+        await farm.work_plots(action=action, coordinates=coordinates, crop_id=crop_id)
 
         await ctx.send(embed=farm.display())
 

--- a/bot/game/farm.py
+++ b/bot/game/farm.py
@@ -91,7 +91,7 @@ class Farm:
                     await self.work_plot(
                         action=action, row=row, column=column, crop_id=crop_id
                     )
-        
+
         for coordinate in coordinates:
             await self.work_plot(
                 action=action,
@@ -111,15 +111,14 @@ class Farm:
             farm_land += "\n"
         embed = Embed(title=self.name, description=farm_land)
         return embed
-    
+
     def get_plots(self, planted: bool = True):
         crops = []
         for crop_row, row in enumerate(self.plot):
             for crop_column, crop in enumerate(row):
-                if planted and crop != None:
+                if planted and crop is not None:
                     crops.append(PlotCoordinate(crop_row, crop_column))
                 else:
                     if not planted and crop is None:
                         crops.append(PlotCoordinate(crop_row, crop_column))
         return crops if crops else None
-

--- a/bot/game/farm.py
+++ b/bot/game/farm.py
@@ -85,37 +85,13 @@ class Farm:
         coordinates: List[PlotCoordinate],
         crop_id: int = None,
     ):
-        if not coordinates:
-            for row in range(self.dimensions.rows):
-                for column in range(self.dimensions.columns):
-                    await self.work_plot(
-                        action=action, row=row, column=column, crop_id=crop_id
-                    )
-
         for coordinate in coordinates:
-            if coordinate.row is None and coordinate.column is not None:
-                for row in range(self.dimensions.rows):
-                    await self.work_plot(
-                        action=action,
-                        row=row,
-                        column=coordinate.column,
-                        crop_id=crop_id,
-                    )
-            elif coordinate.column is None and coordinate.row is not None:
-                for column in range(self.dimensions.columns):
-                    await self.work_plot(
-                        action=action,
-                        row=coordinate.row,
-                        column=column,
-                        crop_id=crop_id,
-                    )
-            elif coordinate.row and coordinate.column:
-                await self.work_plot(
-                    action=action,
-                    row=coordinate.row,
-                    column=coordinate.column,
-                    crop_id=crop_id,
-                )
+            await self.work_plot(
+                action=action,
+                row=coordinate.row,
+                column=coordinate.column,
+                crop_id=crop_id,
+            )
 
     def display(self):
         farm_land = ""
@@ -128,3 +104,15 @@ class Farm:
             farm_land += "\n"
         embed = Embed(title=self.name, description=farm_land)
         return embed
+    
+    def get_plots(self, planted: bool = True):
+        crops = []
+        for crop_row, row in enumerate(self.plot):
+            for crop_column, crop in enumerate(row):
+                if planted and crop != None:
+                    crops.append(PlotCoordinate(crop_row, crop_column))
+                else:
+                    if not planted and crop is None:
+                        crops.append(PlotCoordinate(crop_row, crop_column))
+        return crops if crops else None
+

--- a/bot/game/farm.py
+++ b/bot/game/farm.py
@@ -85,6 +85,13 @@ class Farm:
         coordinates: List[PlotCoordinate],
         crop_id: int = None,
     ):
+        if not coordinates:
+            for row in range(self.dimensions.rows):
+                for column in range(self.dimensions.columns):
+                    await self.work_plot(
+                        action=action, row=row, column=column, crop_id=crop_id
+                    )
+        
         for coordinate in coordinates:
             await self.work_plot(
                 action=action,


### PR DESCRIPTION
Decoupled specific coordinates in farming commands. Plant now takes in the crop name and amount, then plants on the first available plots going left to right row by row. Water and Harvest just works on all planted plots. This requires the crop.work() logic to figure out if the plot is ready to be watered/harvested.